### PR TITLE
Add bus timetable

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,21 @@ bot = new line.Client(line_config);
 // ----------------------------------------------------
 // ルーター設定
 server.get('/', (req, res) => res.send('Hello, LINEBOT!')); //ブラウザ確認用
+server.get('/test', (req, res) => {
+  async function test(){
+    var root = ["00053907", "00053915"];
+    var response = [];
+    for (var idx in root) {
+      var res = await scrape.getBusTime("00291944", "00087909", root[idx],  "07:00", "九大学研都市 → 産学連携");
+      response.push([res.join('\n')]);
+    }
+
+    console.log('OKAERI!');
+    console.log(response);
+  }
+
+  test();
+}); //関数テスト用
 
 server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
   // 先行してLINE側にステータスコード200でレスポンスする
@@ -64,25 +79,35 @@ async function handleEvent(event){
       var code = ["train", "00007420", "00009453", "00000836", "1", "博多 → 九大学研都市駅"];
 
     } else if(event.postback.data == "九大学研都市(産学連携)"){
-      var code = ["bus", "00291944", "00087909", "00053907", "九大学研都市 → 産学連携"];
+      var code = ["bus", "00291944", "00087909", "九大学研都市 → 産学連携"];
+      var root = ["00053907", "00053915"];
 
     } else if(event.postback.data == "産学連携(九大学研都市)"){
-      var code = ["bus", "00087909", "00291944", "00053907", "産学連携 → 九大学研都市"];
-
+      var code = ["bus", "00087909", "00291944", "産学連携 → 九大学研都市"];
+      var root = ["00053907", "00053915", "00053917"];
+      
     } else if(event.postback.data == "九大学研都市(中央図書館)"){
-      var code = ["bus", "00291944", "00291995", "00053907", "九大学研都市 → 中央図書館"];
+      var code = ["bus", "00291944", "00291995", "九大学研都市 → 中央図書館"];
+      var root = ["00053907", "00053914", "00053915"];
 
     } else if(event.postback.data == "中央図書館(九大学研都市)"){
       var code = ["bus", "00291995",　"00291944", "00053907", "中央図書館 → 九大学研都市"];
+      var root = ["00053907", "00053914", "00053915"];
 
     }
 
     if (code[0] == "train") {
       var res = await scrape.getTrainTime(code[1], code[2], code[3], code[4], event.postback.params.time, code[5]);
+      var response = res.join('\n');
+
     } else if (code[0] == "bus") {
-      var res = await scrape.getBusTime(code[1], code[2], code[3], event.postback.params.time, code[4]);
+      var response = [];
+      for (var idx in root) {
+        var res = await scrape.getBusTime(code[1], code[2], root[idx], event.postback.params.time, code[3]);
+        response.push([res.join('\n')]);
+      }
     }
-    var response = res.join('\n');
+
     var responsemsg = {
       type: "text",
       text: response

--- a/index.js
+++ b/index.js
@@ -98,20 +98,22 @@ async function handleEvent(event){
 
     if (code[0] == "train") {
       var res = await scrape.getTrainTime(code[1], code[2], code[3], code[4], event.postback.params.time, code[5]);
-      var response = res.join('\n');
+      var responsemsg = {
+        type: "text",
+        text: res.join('\n')
+      };
 
     } else if (code[0] == "bus") {
-      var response = [];
+      var responsemsg = [];
+
       for (var idx in root) {
         var res = await scrape.getBusTime(code[1], code[2], root[idx], event.postback.params.time, code[3]);
-        response.push([res.join('\n')]);
+        responsemsg.push({
+          type: "text",
+          text: res.join('\n')
+        });
       }
     }
-
-    var responsemsg = {
-      type: "text",
-      text: response
-    };
 
   // postback else
   } else if (event.message.text.indexOf("でんしゃくん") !== -1){

--- a/scraping.js
+++ b/scraping.js
@@ -134,7 +134,8 @@ class Scraping {
 
         /* 
         Example of scraping link
-        https://www.navitime.co.jp/bus/diagram/timelist?departure=00291944&arrival=00087909&line=00053907
+        https://www.navitime.co.jp/bus/diagram/timelist?departure=00291944&arrival=00087909&line=00053907 //学園通り
+        https://www.navitime.co.jp/bus/diagram/timelist?departure=00291944&arrival=00087909&line=00053915 //周船寺
         */
         const cheerioObject = await cheerio.fetch('https://www.navitime.co.jp/bus/diagram/timelist',{departure:departure,arrival:arrival,line:line});
         let lists = cheerioObject.$('span').text();
@@ -181,6 +182,7 @@ class Scraping {
         }
         // 先頭に挿入
         replyMessage.unshift(name);
+        console.log(replyMessage);
         return replyMessage;
     }
 }

--- a/scraping.js
+++ b/scraping.js
@@ -181,14 +181,14 @@ class Scraping {
           replyMessage.push("終バス終わったよ！");
         }
         // 先頭に挿入
-        linename = {
+        var linename = {
           "00053907": "学園通り経由",
           "00053914": "横浜西経由",
           "00053915": "周船寺経由",
           "00053917": "直行",
-        }
+        };
+        replyMessage.unshift("[路線："+linename[line]+"]")
         replyMessage.unshift(name);
-        replyMessage.unshift("路線："+linename[line])
         console.log(replyMessage);
         return replyMessage;
     }

--- a/scraping.js
+++ b/scraping.js
@@ -181,7 +181,14 @@ class Scraping {
           replyMessage.push("終バス終わったよ！");
         }
         // 先頭に挿入
+        linename = {
+          "00053907": "学園通り経由",
+          "00053914": "横浜西経由",
+          "00053915": "周船寺経由",
+          "00053917": "直行",
+        }
         replyMessage.unshift(name);
+        replyMessage.unshift("路線："+linename[line])
         console.log(replyMessage);
         return replyMessage;
     }


### PR DESCRIPTION
## 概要
バスの路線が「学園通り経由」のみだったので
他にも路線を調べて返信するようにした。

## 詳細（主に技術的変更点）
root配列で路線情報を保持して
路線の数だけ情報取得・返信を行うように設計した。

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）
従来と同様。
バスに関して返信が路線の数だけくる。

## 保留した項目・TODOリスト
路線ごとにスクレイピングするため，動作が重くなってしまう。
- [ ] 動作スピード向上のためのコーディング

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
<img src="https://user-images.githubusercontent.com/51741264/87039056-92c43000-c229-11ea-9576-0f0cc5752e22.png" width=40%>
